### PR TITLE
Migrate OpenWeatherMap from One Call 3.0 to One Call 4.0 (fixes #63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ In particular, this plugin is the launching plugin for [homebridge-lib](https://
 You need to obtain an [API key](https://openweathermap.org/price) from OpenWeatherMap.
 As Homebridge WS uses the `onecall` API endpoint, a _One Call by Call_ subscription plan is needed for new API keys.
 Old API keys under the the _Free_ plan of the _Current weather and forecasts collection_ still work, but new API keys need the _One Call by Call_ plan.
+Note that OpenWeatherMap pin each API key to a single version of the One Call API, through its subscription: older keys use One Call 3.0; newer keys use One Call 4.0.
+Homebridge WS automatically detects which version your API key supports.
+To force a specific version, set _One Call API Version_ under _Advanced Settings_.
 
 You need a server to run Homebridge.
 This can be anything running [Node.js](https://nodejs.org): from a Raspberry Pi, a NAS system, or an always-on PC running Linux, macOS, or Windows.

--- a/config.schema.json
+++ b/config.schema.json
@@ -59,6 +59,15 @@
           "type": "string"
         }
       },
+      "onecallVersion": {
+        "title": "One Call API Version",
+        "description": "One Call API version to use.  Default: automatic detection.",
+        "type": "string",
+        "oneOf": [
+          { "title": "3.0", "enum": ["3.0"] },
+          { "title": "4.0", "enum": ["4.0"] }
+        ]
+      },
       "timeout": {
         "title": "Timeout",
         "description": "Timeout in seconds.  Default: 15.",
@@ -124,6 +133,7 @@
       "title": "Advanced Settings",
       "description": "Don't change these, unless you understand what you're doing.",
       "items": [
+        "onecallVersion",
         "timeout"
       ]
     }

--- a/lib/WsPlatform.js
+++ b/lib/WsPlatform.js
@@ -34,6 +34,9 @@ class WsPlatform extends Platform {
       .intKey('hourlyForecasts', 0, 47)
       .boolKey('leakSensor')
       .listKey('locations')
+      .enumKey('onecallVersion')
+      .enumKeyValue('onecallVersion', '3.0')
+      .enumKeyValue('onecallVersion', '4.0')
       .intKey('timeout', 1, 60)
       .on('userInputError', (message) => {
         this.warn('config.json: %s', message)
@@ -150,7 +153,43 @@ class WsPlatform extends Platform {
   }
 
   async onecall (lat, lon) {
-    // One Call API 3.0 returned current + hourly + daily in a single response.
+    // OpenWeatherMap pins each API key to a single One Call version through
+    // its subscription: keys on the original One Call by Call plan get a 401
+    // on 4.0, keys on the newer plan get a 401 on 3.0 (#63).  Use the
+    // configured version when set; otherwise detect the working version on
+    // the first call and remember it for the session.
+    const version = this.config.onecallVersion ?? this._onecallVersion
+    if (version != null) {
+      return version === '4.0'
+        ? this._onecall4(lat, lon)
+        : this._onecall3(lat, lon)
+    }
+    const response = await this._client.get(
+      `3.0/onecall?lat=${lat}&lon=${lon}&exclude=minutely`
+    )
+    if (response.body.cod == null || response.body.cod === 200) {
+      this._onecallVersion = '3.0'
+      this.log('using One Call API v3.0')
+      return response
+    }
+    if (response.body.cod !== 401) {
+      return this.checkResponse(response) // throws
+    }
+    const result = await this._onecall4(lat, lon) // throws if 4.0 fails as well
+    this._onecallVersion = '4.0'
+    this.log('using One Call API v4.0')
+    return result
+  }
+
+  async _onecall3 (lat, lon) {
+    const response = await this._client.get(
+      `3.0/onecall?lat=${lat}&lon=${lon}&exclude=minutely`
+    )
+    return this.checkResponse(response)
+  }
+
+  async _onecall4 (lat, lon) {
+    // One Call API 3.0 returns current + hourly + daily in a single response.
     // One Call API 4.0 splits these across separate endpoints, each wrapping its
     // records in a `data` array.  Fetch the parts we need and reassemble a
     // 3.0-shaped object so the rest of the plugin (WsService) is unchanged.

--- a/lib/WsPlatform.js
+++ b/lib/WsPlatform.js
@@ -150,10 +150,39 @@ class WsPlatform extends Platform {
   }
 
   async onecall (lat, lon) {
-    const response = await this._client.get(
-      `3.0/onecall?lat=${lat}&lon=${lon}&exclude=minutely`
-    )
-    return this.checkResponse(response)
+    // One Call API 3.0 returned current + hourly + daily in a single response.
+    // One Call API 4.0 splits these across separate endpoints, each wrapping its
+    // records in a `data` array.  Fetch the parts we need and reassemble a
+    // 3.0-shaped object so the rest of the plugin (WsService) is unchanged.
+    //
+    // - `current` is always needed (drives the main weather services, and the
+    //   Weather service also reads daily[0] for today's min/max and rain).
+    // - `hourly` (timeline/1h) is only fetched when hourly forecasts are
+    //   configured.  It returns up to 20 records, so hours beyond ~19 are
+    //   unavailable and those forecast services stay blank.
+    const needHourly = this.config.hourlyForecasts > 0
+    const jobs = [
+      this._client.get(`4.0/onecall/current?lat=${lat}&lon=${lon}`),
+      this._client.get(`4.0/onecall/timeline/1day?lat=${lat}&lon=${lon}`)
+    ]
+    if (needHourly) {
+      jobs.push(this._client.get(`4.0/onecall/timeline/1h?lat=${lat}&lon=${lon}`))
+    }
+    const [current, daily, hourly] = await Promise.all(jobs)
+    this.checkResponse(current)
+    this.checkResponse(daily)
+    if (needHourly) {
+      this.checkResponse(hourly)
+    }
+    return {
+      body: {
+        lat,
+        lon,
+        current: current.body.data?.[0] ?? {},
+        daily: daily.body.data ?? [],
+        hourly: needHourly ? (hourly.body.data ?? []) : []
+      }
+    }
   }
 
   async geocode (location) {

--- a/lib/WsService.js
+++ b/lib/WsService.js
@@ -22,6 +22,30 @@ function windDirection (degrees) {
   return windDirections[Math.round(degrees * 16 / 360)]
 }
 
+// One Call API 4.0's daily timeline (timeline/1day) omits the `weather` array
+// that 3.0 provided (it comes back as null).  Synthesize a single condition
+// from the numeric rain/snow/clouds fields so the daily forecast still reports
+// a sensible OpenWeatherMap condition id and label.
+function dailyWeather (o) {
+  if (Array.isArray(o.weather) && o.weather.length > 0) {
+    return o.weather
+  }
+  const clouds = Number(o.clouds) || 0
+  let condition
+  if (Number(o.snow) > 0) {
+    condition = { id: 601, main: 'Snow' }
+  } else if (Number(o.rain) > 0) {
+    condition = { id: 501, main: 'Rain' }
+  } else if (clouds >= 85) {
+    condition = { id: 804, main: 'Clouds' }
+  } else if (clouds >= 11) {
+    condition = { id: 802, main: 'Clouds' }
+  } else {
+    condition = { id: 800, main: 'Clear' }
+  }
+  return [condition]
+}
+
 class WsService extends ServiceDelegate {
   static get Temperature () { return Temperature }
 
@@ -422,23 +446,24 @@ class DailyForecast extends WsService {
     if (o == null) {
       return
     }
+    const weather = dailyWeather(o)
 
     this.values.apparentTemperature = Math.round(o.feels_like.day * 10) / 10
     this.values.clouds = o.clouds
-    this.values.condition = o.weather.map((condition) => {
+    this.values.condition = weather.map((condition) => {
       return condition.main
     }).join(', ')
-    this.values.conditionCategory = o.weather[0].id
+    this.values.conditionCategory = weather[0].id
     this.values.day = toWeekDay(o.dt)
     this.values.dewPoint = o.dew_point
     this.values.humidity = o.humidity
     this.values.observationTime = toDate(o.dt)
     this.values.pressure = o.pressure
-    this.values.rain = o.weather.reduce((rain, condition) => {
+    this.values.rain = weather.reduce((rain, condition) => {
       return rain || [2, 3, 5].includes(Math.floor(condition.id / 100))
     }, false)
     this.values.rain24h = o.rain != null ? o.rain : 0
-    this.values.snow = o.weather.reduce((snow, condition) => {
+    this.values.snow = weather.reduce((snow, condition) => {
       return snow || (Math.floor(condition.id / 100) === 6)
     }, false)
     this.values.sunrise = toDate(o.sunrise)


### PR DESCRIPTION
One Call API 3.0 now returns HTTP 401 ("using One Call 3.0 requires a separate
subscription to the One Call by Call plan") for keys whose subscription is
directed to the newer API, which breaks the plugin entirely (the 2.5/weather
init call still works, so locations resolve, but every heartbeat onecall fails).


`WsPlatform.onecall()` now uses the One Call 4.0 endpoints, which split the
single 3.0 response into three `data`-array endpoints, and reassembles a
3.0-shaped `{ current, daily, hourly }` object so the rest of the plugin is
unchanged:

| 3.0 | 4.0 |
| --- | --- |
| `.current`  | `4.0/onecall/current` → `data[0]` |
| `.hourly[]` | `4.0/onecall/timeline/1h` → `data[]` (≤20) |
| `.daily[]`  | `4.0/onecall/timeline/1day` → `data[]` (≤10) |

- `current` + `daily` are always fetched (the Weather service reads `daily[0]`
  for today's min/max and rain even with no forecasts configured); the hourly
  timeline is fetched only when `hourlyForecasts > 0`.
- The 4.0 daily timeline returns `weather: null`, so `WsService.DailyForecast`
  synthesizes a condition id/label from the numeric `rain`/`snow`/`clouds`
  fields — avoids a crash and keeps the daily forecast tiles meaningful.

Notes:

- Requires the same "One Call by Call" subscription as 3.0 did; this only
  changes which API version the plugin targets.
- The 1h timeline returns ≤20 records per page (no pagination added), so
  hourly forecasts beyond ~19h stay blank. Daily ≤10 covers the 0–7 range.
- Tested live against a subscribed key (current + timeline/1day + timeline/1h
  all 200), running in homebridge-ws 2.7.45 with dailyForecasts configured.

Fixes #63
